### PR TITLE
Allow creation of subprojects by publishing test data

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,10 @@ Register (project, sub-project, language) with the statistic server. You may not
 
     curl -kv https://<servername>/meta/projects -H "Content-Type: application/json" -H "auth-token: <meta-auth-token>"
 
-Return a list of all projects known by the statistic server in the format:
--> {"projects": [{"project": "foo",
+Return a list of all projects known by the statistic server in the format: `{"projects": [{"project": "foo",
                   "subprojects": [{"subproject": "bar",
                                    "languages": [{"language": "java"}, {"language": "clojure"}]},
-                                  {"subproject": "baz", "languages": ...}"
+                                  {"subproject": "baz", "languages": ...}"`
 
 
 #Build

--- a/src/fdc_ts/core.clj
+++ b/src/fdc_ts/core.clj
@@ -77,7 +77,7 @@
   :allowed-methods [:put]
   :service-available? auth-publish-configured
   :authorized? auth-publish
-  :allowed? (comp project-exists? :json)
+  :allowed? (comp main-project-exists? :json)
   :put! (fn [ctx] (insert-coverage (:json ctx))))
 
 (defresource get-project-coverage-statistic [time project subproject language]

--- a/src/fdc_ts/core.clj
+++ b/src/fdc_ts/core.clj
@@ -78,7 +78,9 @@
   :service-available? auth-publish-configured
   :authorized? auth-publish
   :allowed? (comp main-project-exists? :json)
-  :put! (fn [ctx] (insert-coverage (:json ctx))))
+  :put! (fn [ctx] 
+          (when (not (project-exists? (:json ctx))) (add-project (:json ctx)))
+          (insert-coverage (:json ctx))))
 
 (defresource get-project-coverage-statistic [time project subproject language]
   :available-media-types ["application/json"]

--- a/src/fdc_ts/projects.clj
+++ b/src/fdc_ts/projects.clj
@@ -14,7 +14,8 @@
                                           :language language}))))
 
 (defn lookup-main-project [{:keys [project language]}]
-  (lookup-project {:project project :language language}))
+  (first (sql/select projects (sql/where {:project project
+                                          :language language}))))
 
 (def project-exists? (comp boolean lookup-project))
 

--- a/src/fdc_ts/projects.clj
+++ b/src/fdc_ts/projects.clj
@@ -13,7 +13,12 @@
                                           :subproject subproject
                                           :language language}))))
 
+(defn lookup-main-project [{:keys [project language]}]
+  (lookup-project {:project project :language language}))
+
 (def project-exists? (comp boolean lookup-project))
+
+(def main-project-exists? (comp boolean lookup-main-project))
 
 (defn add-project [{:keys [:project :subproject :language] :as data}]
   (log :info "adding project with " data)

--- a/test/fdc_ts/projects_test.clj
+++ b/test/fdc_ts/projects_test.clj
@@ -67,7 +67,11 @@
   (let [prj (lookup-project +first-project+)]
     (is (true? (_projects-equal? +first-project+ prj)))))
 
-(deftest ^:integration should-find-project
+(deftest ^:integration should-find-main-project
+  (let [prj (lookup-main-project +first-project+)]
+    (is (true? (_projects-equal? +first-project+ prj)))))
+
+(deftest ^:integration should-not-find-project
   (is (nil? (lookup-project {:project "not-existing"}))))
 
 


### PR DESCRIPTION
This change should allow the implicit creation of subprojects by publishing test coverage for projects whose main-project already exist.